### PR TITLE
fix: successMessage not changing

### DIFF
--- a/src/templates/Challenges/classic/Show.js
+++ b/src/templates/Challenges/classic/Show.js
@@ -14,6 +14,8 @@ import CompletionModal from '../components/CompletionModal';
 import HelpModal from '../components/HelpModal';
 import ResetModal from '../components/ResetModal';
 
+import { randomCompliment } from '../utils/get-words';
+
 import { challengeTypes } from '../../../../utils/challengeTypes';
 import { ChallengeNode } from '../../../redux/propTypes';
 import {
@@ -21,7 +23,8 @@ import {
   challengeFilesSelector,
   initTests,
   updateChallengeMeta,
-  challengeMounted
+  challengeMounted,
+  updateSuccessMessage
 } from '../redux';
 
 import './classic.css';
@@ -32,7 +35,13 @@ const mapStateToProps = createSelector(challengeFilesSelector, files => ({
 
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
-    { createFiles, initTests, updateChallengeMeta, challengeMounted },
+    {
+      createFiles,
+      initTests,
+      updateChallengeMeta,
+      challengeMounted,
+      updateSuccessMessage
+    },
     dispatch
   );
 
@@ -51,7 +60,8 @@ const propTypes = {
       nextchallengePath: PropTypes.string
     })
   }),
-  updateChallengeMeta: PropTypes.func.isRequired
+  updateChallengeMeta: PropTypes.func.isRequired,
+  updateSuccessMessage: PropTypes.func.isRequired
 };
 
 class ShowClassic extends PureComponent {
@@ -61,12 +71,14 @@ class ShowClassic extends PureComponent {
       createFiles,
       initTests,
       updateChallengeMeta,
+      updateSuccessMessage,
       data: { challengeNode: { files, title, fields: { tests } } },
       pathContext: { challengeMeta }
     } = this.props;
     createFiles(files);
     initTests(tests);
     updateChallengeMeta({ ...challengeMeta, title });
+    updateSuccessMessage(randomCompliment());
     challengeMounted(challengeMeta.id);
   }
 
@@ -77,11 +89,13 @@ class ShowClassic extends PureComponent {
       createFiles,
       initTests,
       updateChallengeMeta,
+      updateSuccessMessage,
       data: {
         challengeNode: { files, title: currentTitle, fields: { tests } }
       },
       pathContext: { challengeMeta }
     } = this.props;
+    updateSuccessMessage(randomCompliment());
     if (prevTitle !== currentTitle) {
       createFiles(files);
       initTests(tests);

--- a/src/templates/Challenges/project/Show.js
+++ b/src/templates/Challenges/project/Show.js
@@ -5,16 +5,27 @@ import { connect } from 'react-redux';
 
 import Helmet from 'react-helmet';
 
+import { randomCompliment } from '../utils/get-words';
+
 import { ChallengeNode } from '../../../redux/propTypes';
 import SidePanel from './Side-Panel';
 import ToolPanel from './Tool-Panel';
 import HelpModal from '../components/HelpModal';
 import { bindActionCreators } from 'redux';
-import { updateChallengeMeta, createFiles } from '../redux';
+import {
+  updateChallengeMeta,
+  createFiles,
+  updateSuccessMessage
+} from '../redux';
 
 const mapStateToProps = () => ({});
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ updateChallengeMeta, createFiles }, dispatch);
+  bindActionCreators(
+    {
+      updateChallengeMeta,
+      createFiles,
+      updateSuccessMessage
+    }, dispatch);
 
 const propTypes = {
   createFiles: PropTypes.func.isRequired,
@@ -24,7 +35,8 @@ const propTypes = {
   pathContext: PropTypes.shape({
     challengeMeta: PropTypes.object
   }),
-  updateChallengeMeta: PropTypes.func.isRequired
+  updateChallengeMeta: PropTypes.func.isRequired,
+  updateSuccessMessage: PropTypes.func.isRequired
 };
 
 export class Project extends PureComponent {
@@ -33,9 +45,11 @@ export class Project extends PureComponent {
       createFiles,
       data: { challengeNode: { title } },
       pathContext: { challengeMeta },
-      updateChallengeMeta
+      updateChallengeMeta,
+      updateSuccessMessage
     } = this.props;
     createFiles({});
+    updateSuccessMessage(randomCompliment());
     return updateChallengeMeta({ ...challengeMeta, title });
   }
 
@@ -45,8 +59,10 @@ export class Project extends PureComponent {
       createFiles,
       data: { challengeNode: { title: currentTitle } },
       pathContext: { challengeMeta },
-      updateChallengeMeta
+      updateChallengeMeta,
+      updateSuccessMessage
     } = this.props;
+    updateSuccessMessage(randomCompliment());
     if (prevTitle !== currentTitle) {
       createFiles({});
       updateChallengeMeta({ ...challengeMeta, title: currentTitle });


### PR DESCRIPTION
Made use of existing (unused) `randomCompliment()` from `src/templates/utils/get-words.js` to generate random compliment.

Implemented updates into `componentDidMount` and `componentDidUpdate` for the `ShowClassic` and `Project` components using existing `updateSuccessMessage` action.

Closes #35