### PR TITLE
Fix typo, add instruction to copy .env in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,17 @@
 # Contributing
 
-Prerequistits| Minimum Version
+Prerequisites | Minimum Version
 |---|---|
 node | ^8.11.x
 [yarn](https://yarnpkg.com/en/) | ^1.3.0
 
 
 1. Fork the repo
-2. clone locally
+2. Clone locally
 3. `yarn install`
-4. `git branch -b <your-branch-name>`
-5. `yarn develop`
-5. Make your changes
-6. Make a PR
-7. Bask in the glory of your accomplishments
+4. `git checkout branch -b <your-branch-name>`
+5. `cp sample.env .env`
+6. `yarn develop`
+7. Make your changes
+8. Make a PR
+9. Bask in the glory of your accomplishments


### PR DESCRIPTION
Fix for https://github.com/freeCodeCamp/learn/issues/44