### PR TITLE
Fix editor menu color

### DIFF
--- a/src/templates/Challenges/classic/classic.css
+++ b/src/templates/Challenges/classic/classic.css
@@ -13,3 +13,8 @@
   display: flex;
   align-items: end;
 }
+
+.monaco-menu .action-label { 
+  color: #a2bd9b; 
+  letter-spacing: 0.02em;
+}


### PR DESCRIPTION
Closes #52

- Change menu color (contrast ratio 6.58, meets minimum [accessibility guideline](https://developers.google.com/web/fundamentals/accessibility/accessible-styles#color_and_contrast))
- Add slight letter-spacing to make small text more legible