### PR TITLE
Fix/monaco resizing

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,7 +10,7 @@ exports.onCreateNode = function onCreateNode({ node, boundActionCreators }) {
   if (node.internal.type === 'ChallengeNode') {
     const { tests = [], block, title, superBlock } = node;
 
-    const slug = `/${dasherize(superBlock)}/${dasherize(block)}/${dasherize(
+    const slug = `/${dasherize(block)}/${dasherize(
       title
     )}`;
     createNodeField({ node, name: 'slug', value: slug });

--- a/src/templates/Challenges/classic/Editor.js
+++ b/src/templates/Challenges/classic/Editor.js
@@ -8,6 +8,7 @@ import { executeChallenge, updateFile } from '../redux';
 
 const propTypes = {
   contents: PropTypes.string,
+  dimensions: PropTypes.object,
   executeChallenge: PropTypes.func.isRequired,
   ext: PropTypes.string,
   fileKey: PropTypes.string,
@@ -49,13 +50,8 @@ class Editor extends PureComponent {
     this.focusEditor = this.focusEditor.bind(this);
   }
 
-  componentDidMount() {
-    window.addEventListener("resize", this.resizeEditor);
-  }
-
   componentWillUnmount() {
     document.removeEventListener('keyup', this.focusEditor);
-    window.removeEventListener("resize", this.resizeEditor);
   }
 
   editorDidMount(editor, monaco) {
@@ -85,7 +81,11 @@ class Editor extends PureComponent {
     updateFile({ key: fileKey, editorValue });
   }
 
-  resizeEditor = () => this._editor.layout();
+  componentDidUpdate(prevProps) {
+    if (this.props.dimensions !== prevProps.dimensions && this._editor) {
+      this._editor.layout();
+    }
+  }
 
   render() {
     const { contents, ext } = this.props;

--- a/src/templates/Challenges/classic/Show.js
+++ b/src/templates/Challenges/classic/Show.js
@@ -85,28 +85,6 @@ const propTypes = {
 };
 
 class ShowClassic extends PureComponent {
-  constructor() {
-    super()
-    this.resizeProps = {
-      // onStopResize: this.onStopResize.bind(this),
-      onResize: this.onResize.bind(this)
-    }
-  }
-
-  onResize(e) {
-    if (e.domElement) {
-      // e.domElement.classList.add('resizing');
-      this.forceUpdate();
-    }
-  }
-
-  // onStopResize(e) {
-  //   if (e.domElement) {
-  //     // e.domElement.classList.remove('resizing');
-  //     // console.log('stop working')
-  //   }
-  // }
-
   componentDidMount() {
     const {
       challengeMounted,
@@ -122,7 +100,6 @@ class ShowClassic extends PureComponent {
     updateChallengeMeta({ ...challengeMeta, title });
     updateSuccessMessage(randomCompliment());
     challengeMounted(challengeMeta.id);
-    // window.addEventListener("resize", this.resizeEditor.bind(this));
   }
 
   componentDidUpdate(prevProps) {
@@ -165,14 +142,14 @@ class ShowClassic extends PureComponent {
     const editors = Object.keys(files)
       .map(key => files[key])
       .map((file, index) => (
-        <Fragment key={file.key + index}>
+        <ReflexContainer orientation='horizontal' key={file.key + index}>
           {index !== 0 && <ReflexSplitter />}
-          <ReflexElement flex={1}>
+          <ReflexElement flex={1} propagateDimensions={true} renderOnResize={true} renderOnResizeRate={20}>
             <Editor {...file} fileKey={file.key} />
           </ReflexElement>
-          {index + 1 === Object.keys(files).length && <ReflexSplitter />}
+          {index + 1 === Object.keys(files).length && <ReflexSplitter propagate={true} />}
           {index + 1 === Object.keys(files).length ? (
-            <ReflexElement flex={0.25}>
+            <ReflexElement flex={0.25} propagateDimensions={true} renderOnResize={true} renderOnResizeRate={20}>
               <Output
                 defaultOutput={`
 /**
@@ -185,9 +162,8 @@ class ShowClassic extends PureComponent {
               />
             </ReflexElement>
           ) : null}
-        </Fragment>
+        </ReflexContainer>
       ));
-
     const showPreview =
       challengeType === challengeTypes.html ||
       challengeType === challengeTypes.modern;
@@ -206,10 +182,8 @@ class ShowClassic extends PureComponent {
             />
           </ReflexElement>
           <ReflexSplitter />
-          <ReflexElement flex={1} {...this.resizeProps}>
-            <ReflexContainer orientation='horizontal'>
-              {editors}
-            </ReflexContainer>
+          <ReflexElement flex={1}>
+            {editors}
           </ReflexElement>
           <ReflexSplitter />
           <ReflexElement flex={0.5}>

--- a/src/templates/Challenges/classic/classic.css
+++ b/src/templates/Challenges/classic/classic.css
@@ -1,6 +1,5 @@
-.editor{
+.editor {
   height: 100%;
-  margin-bottom: 1.45rem;
 }
 
 .instructions-panel {
@@ -12,6 +11,7 @@
   height: 100%;
   display: flex;
   align-items: end;
+  overflow: hidden;
 }
 
 .monaco-menu .action-label { 

--- a/src/templates/Challenges/components/Output.js
+++ b/src/templates/Challenges/components/Output.js
@@ -4,6 +4,7 @@ import MonacoEditor from 'react-monaco-editor';
 
 const propTypes = {
   defaultOutput: PropTypes.string,
+  dimensions: PropTypes.object,
   height: PropTypes.number,
   output: PropTypes.string
 };
@@ -22,22 +23,20 @@ const options = {
 };
 
 class Output extends PureComponent {
-  constructor(...props) {
+  constructor() {
     super();
 
     this._editor = null;
   }
 
-  componentDidMount() {
-    window.addEventListener("resize", this.resizeOutput);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener("resize", this.resizeOutput);
-  }
-
-  editorDidMount(editor, monaco) {
+  editorDidMount(editor) {
     this._editor = editor;
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.dimensions !== prevProps.dimensions && this._editor) {
+      this._editor.layout();
+    }
   }
 
   resizeOutput = () => this._editor.layout();


### PR DESCRIPTION
Reworked the way that the editor and output are rendered when the browser window / panes are resized horizontally. Moved the ReflexContainer elements into the editors variable to get vertical resizing working. Also, removed the margin-bottom property from the .editor class in classic.css and set overflow to hidden in .react-monaco-editor-container. By doing this it prevents the browser scrollbars from appearing and removes the white space at the bottom of the editor / output panes when scrolling all the way down past the code.

Closes #56 and #49.