### PR TITLE
fix: unintended assert code shown

### DIFF
--- a/src/templates/Challenges/classic/Editor.js
+++ b/src/templates/Challenges/classic/Editor.js
@@ -78,7 +78,14 @@ class Editor extends PureComponent {
 
   onChange(editorValue) {
     const { updateFile, fileKey } = this.props;
-    updateFile({ key: fileKey, editorValue });
+
+    /* for regular "" */
+    const totalAp = (editorValue.match(/\"/g) || []).length;
+    /* for escape \" */
+    const totalBap = (editorValue.match(/\\"/g) || []).length;
+    if ((totalAp - totalBap) % 2 === 0) {
+      updateFile({ key: fileKey, editorValue });
+    }
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
Fix unintended assert code shown on the iframe runner.

This thing happened when there is unclosed parentheses ```"```

It works, but I'm a bit concern about the performance for large files.
Closes Issue #66 