### PR TITLE
Fix: Babel errors in the browser console for user code

### DIFF
--- a/src/templates/Challenges/rechallenge/transformers.js
+++ b/src/templates/Challenges/rechallenge/transformers.js
@@ -82,10 +82,12 @@ function tryTransform(wrap = identity) {
   return function transformWrappedPoly(source) {
     const result = attempt(wrap, source);
     if (isError(result)) {
-      const friendlyError = `${result}`
-        .match(/[\w\W]+?\n/)[0]
-        .replace(' unknown:', '');
-      throw new Error(friendlyError);
+      console.error(result);
+      // note(Bouncey): Error thrown here to collapse the build pipeline
+      // At the minute, it will not bubble up
+      // We collapse the pipeline so the app doesn't fall over trying
+      // parse bad code (syntax/type errors etc...)
+      throw new Error();
     }
     return result;
   };
@@ -110,12 +112,7 @@ export const sassTransformer = cond([
   [stubTrue, identity]
 ]);
 
-export const _transformers = [
-  // addLoopProtectHtmlJsJsx,
-  replaceNBSP,
-  babelTransformer,
-  sassTransformer
-];
+export const _transformers = [replaceNBSP, babelTransformer, sassTransformer];
 
 export function applyTransformers(file, transformers = _transformers) {
   return transformers.reduce((obs, transformer) => {

--- a/src/templates/Challenges/redux/completion-epic.js
+++ b/src/templates/Challenges/redux/completion-epic.js
@@ -126,7 +126,7 @@ export default function completionEpic(action$, { getState }) {
       const { nextChallengePath, introPath, challengeType } = meta;
       const next = of(push(introPath ? introPath : nextChallengePath));
       const closeChallengeModal = of(closeModal('completion'));
-      let submitter = () => of({type: 'no-user-signed-in'});
+      let submitter = () => of({ type: 'no-user-signed-in' });
       if (
         !(challengeType in submitTypes) ||
         !(submitTypes[challengeType] in submitters)
@@ -139,7 +139,6 @@ export default function completionEpic(action$, { getState }) {
       if (isSignedInSelector(state)) {
         submitter = submitters[submitTypes[challengeType]];
       }
-
 
       return submitter(type, state).pipe(
         concat(next),

--- a/src/templates/Challenges/redux/index.js
+++ b/src/templates/Challenges/redux/index.js
@@ -104,10 +104,13 @@ export const updateSuccessMessage = createAction(types.updateSuccessMessage);
 
 export const lockCode = createAction(types.lockCode);
 export const unlockCode = createAction(types.unlockCode);
-export const disableJSOnError = createAction(types.disableJSOnError, err => {
-  console.error(err);
-  return {};
-});
+export const disableJSOnError = createAction(
+  types.disableJSOnError,
+  ({ payload }) => {
+    console.error(JSON.stringify(payload));
+    return null;
+  }
+);
 export const storedCodeFound = createAction(types.storedCodeFound);
 export const noStoredCodeFound = createAction(types.noStoredCodeFound);
 

--- a/src/templates/Challenges/utils/build.js
+++ b/src/templates/Challenges/utils/build.js
@@ -8,7 +8,6 @@ import {
   challengeFilesSelector,
   isJSEnabledSelector,
   challengeMetaSelector,
-  disableJSOnError,
   backendFormValuesSelector
 } from '../redux';
 import {
@@ -55,8 +54,7 @@ export function buildFromFiles(state, shouldProxyConsole) {
     ::pipe(shouldProxyConsole ? proxyLoggerTransformer : identity)
     ::pipe(jsToHtml)
     ::pipe(cssToHtml)
-    ::concatHtml(finalRequires, template)
-    .catch(err => disableJSOnError(err));
+    ::concatHtml(finalRequires, template);
 }
 
 export function buildBackendChallenge(state) {


### PR DESCRIPTION
These changes will print out babel errors to the console and will help to not crash the app when bad/unfinished code is in the editor.