### PR TITLE
Fix Firefox Pane Resizing

### DIFF
--- a/src/templates/Challenges/classic/Show.js
+++ b/src/templates/Challenges/classic/Show.js
@@ -85,6 +85,27 @@ const propTypes = {
 };
 
 class ShowClassic extends PureComponent {
+  constructor() {
+    super()
+
+    this.resizeProps = {
+      onStopResize: this.onStopResize.bind(this),
+      onResize: this.onResize.bind(this)
+    }
+
+    this.state = {
+      resizing: false
+    }
+  }
+
+  onResize() {
+    this.setState({ resizing: true });
+  }
+
+  onStopResize() {
+    this.setState({ resizing: false });
+  }
+
   componentDidMount() {
     const {
       challengeMounted,
@@ -136,6 +157,7 @@ class ShowClassic extends PureComponent {
   }
 
   render() {
+    // console.log(this.state)
     const {
       data: {
         challengeNode: {
@@ -154,17 +176,18 @@ class ShowClassic extends PureComponent {
       .map(key => files[key])
       .map((file, index) => (
         <ReflexContainer key={file.key + index} orientation='horizontal'>
-          {index !== 0 && <ReflexSplitter />}
+          {index !== 0 && <ReflexSplitter propagate={true} {...this.resizeProps} />}
           <ReflexElement
             flex={1}
             propagateDimensions={true}
             renderOnResize={true}
             renderOnResizeRate={20}
+            {...this.resizeProps}
             >
             <Editor {...file} fileKey={file.key} />
           </ReflexElement>
           {index + 1 === Object.keys(files).length && (
-            <ReflexSplitter propagate={true} />
+            <ReflexSplitter propagate={true} {...this.resizeProps} />
           )}
           {index + 1 === Object.keys(files).length ? (
             <ReflexElement
@@ -172,6 +195,7 @@ class ShowClassic extends PureComponent {
               propagateDimensions={true}
               renderOnResize={true}
               renderOnResizeRate={20}
+              {...this.resizeProps}
               >
               <Output
                 defaultOutput={`
@@ -196,18 +220,18 @@ class ShowClassic extends PureComponent {
         <Helmet title={`${blockNameTitle} | Learn freeCodeCamp`} />
         <ToolPanel guideUrl={guideUrl} />
         <ReflexContainer orientation='vertical'>
-          <ReflexElement flex={1}>
+          <ReflexElement flex={1} {...this.resizeProps}>
             <SidePanel
               className='full-height'
               description={description}
               title={blockNameTitle}
             />
           </ReflexElement>
-          <ReflexSplitter />
-          <ReflexElement flex={1}>{editors}</ReflexElement>
-          <ReflexSplitter />
-          <ReflexElement flex={0.5}>
-            {showPreview ? <Preview className='full-height' /> : null}
+          <ReflexSplitter propagate={true} {...this.resizeProps} />
+          <ReflexElement flex={1} {...this.resizeProps}>{editors}</ReflexElement>
+          <ReflexSplitter propagate={true} {...this.resizeProps} />
+          <ReflexElement flex={0.5} {...this.resizeProps}>
+            {showPreview ? <Preview className='full-height' disableIframe={this.state.resizing} /> : null}
             <Spacer />
             <TestSuite tests={tests} />
           </ReflexElement>

--- a/src/templates/Challenges/classic/classic.css
+++ b/src/templates/Challenges/classic/classic.css
@@ -11,10 +11,9 @@
   height: 100%;
   display: flex;
   align-items: end;
-  overflow: hidden;
 }
 
 .monaco-menu .action-label { 
-  color: #a2bd9b; 
+  color: #a2bd9b;
   letter-spacing: 0.02em;
 }

--- a/src/templates/Challenges/components/Output.js
+++ b/src/templates/Challenges/components/Output.js
@@ -39,8 +39,6 @@ class Output extends PureComponent {
     }
   }
 
-  resizeOutput = () => this._editor.layout();
-
   render() {
     const { output, defaultOutput, height } = this.props;
     return (

--- a/src/templates/Challenges/components/Preview.js
+++ b/src/templates/Challenges/components/Preview.js
@@ -1,17 +1,41 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 
 import './preview.css';
 
 const mainId = 'fcc-main-frame';
 
-export function Preview() {
-  return (
-    <div className='challenge-preview'>
-      <iframe className={'challenge-preview-frame'} id={mainId} />
-    </div>
-  );
+const propTypes = {
+  className: PropTypes.string,
+  disableIframe: PropTypes.bool
+};
+
+class Preview extends PureComponent {
+  constructor(...props) {
+    super(...props)
+
+    this.state = {
+      iframeStatus: this.props.disableIframe
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.disableIframe !== nextProps.disableIframe) {
+      this.setState({ iframeStatus: !this.state.iframeStatus })
+    }
+  }
+
+  render() {
+    const iframeToggle = this.state.iframeStatus ? 'disable' : 'enable';
+    return (
+      <div className={`challenge-preview ${iframeToggle}-iframe`}>
+        <iframe className={'challenge-preview-frame'} id={mainId} />
+      </div>
+    );
+  }
 }
 
 Preview.displayName = 'Preview';
+Preview.propTypes = propTypes;
 
 export default Preview;

--- a/src/templates/Challenges/components/preview.css
+++ b/src/templates/Challenges/components/preview.css
@@ -11,3 +11,11 @@
   padding: 0;
   margin: 0;
 }
+
+.enable-iframe {
+  pointer-events: auto;
+}
+
+.disable-iframe {
+  pointer-events: none;
+}


### PR DESCRIPTION
Added a state to Show.js to track when the panes are being resized and passed said state to Preview.js as a prop. There I used state changes to toggle whether pointer events are set to auto or none. Seems like this was the easiest way to get Firefox to resize the panes the way Chrome does when the mouse moves over an iframe. 

Thought about using the propagateDimensions, renderOnResize, and renderOnResizeRate properties like with the editor here, but was unsure if that would cause the whole Preview component, including whatever is in the iframe, to be re-rendered, rather than just toggling the class. Similarly, I might try to go back and use the props method used here to rework the way the editor is resized if performance with lots of code might become an issue.

Removed the overflow: hidden declaration from the .react-monaco-deditor-container block to fix a bug with resizing the editor / output in Firefox. Seems like there's a longstanding bug with mouse events between two sections of the page where one has the overflow: hidden rule.

Also did some cleanup by removing a console.log line from Output.js that I forgot to delete in the last PR.

Closes #97.