### PR TITLE
WIP: decodeHTMLEntities

### DIFF
--- a/src/templates/Challenges/classic/Show.js
+++ b/src/templates/Challenges/classic/Show.js
@@ -32,6 +32,8 @@ import {
 
 import './classic.css';
 
+import decodeHTMLEntities from '../../../../utils/decodeHTMLEntities';
+
 const mapStateToProps = createSelector(
   challengeFilesSelector,
   challengeTestsSelector,
@@ -200,7 +202,7 @@ class ShowClassic extends PureComponent {
 * Your test output will go here.
 */
 `}
-                output={output}
+                output={decodeHTMLEntities(output)}
               />
             </ReflexElement>
           ) : null}

--- a/utils/decodeHTMLEntities.js
+++ b/utils/decodeHTMLEntities.js
@@ -1,0 +1,27 @@
+/*
+ * Converts HTML entity codes in a string to the characters they represent.
+ *
+ * Example:
+ * `decodeHTMLEntities('Beets &amp; carrots');`
+ * will return "Beets & carrots".
+ *
+ * The regex makes sure we only replace the HTML entities in the string.
+ * For example, the regex would match "&lt;" as well as "&#58;".
+ * The decoding works by setting the innerHTML of a dummy element and then
+ * retrieving the innerText. Per the spec, innerText is a property that
+ * represents the "rendered" text content of an element.
+ *
+ * See:
+ * https://developer.mozilla.org/en-US/docs/Web/API/Node/innerText
+ * https://developer.mozilla.org/en-US/docs/Glossary/Entity
+ *
+ */
+const decodeHTMLEntities = str => {
+  const el = document.createElement('div');
+  return str.replace(/\&[#0-9a-z]+;/gi, enc => {
+    el.innerHTML = enc;
+    return el.innerText;
+  });
+};
+
+export default decodeHTMLEntities;


### PR DESCRIPTION
WIP, please do not merge yet.

@Bouncey this is a first attempt at fixing issue #53. It does decode HTML entities as requested.

Unfortunately there seems to be another bug with the console output. Here is the new output. Note the "\<wbr\>" string in the link on the 2nd line:

```
// running test
Your a element should have the anchor text of "cat photos".
You need an a element that links to http://freecatphotoapp<wbr>.com
Make sure your a element has a closing tag.
// tests completed
```

For reference, here is the test message text:

```
You need an <code>a</code> element that links to <code>http://freecatphotoapp<wbr>.com</code>
```

As you can see, somewhere the HTML elements are getting stripped out, but it looks like it is choking on "\<wbr\>" element for some reason.

If you can point me to where that's happening, I can try to fix that in this issue to. Or if you want, I can open another issue and we can get this fix merged.
