### PR TITLE
Fix: 'Testing with Chai' 404 error

### DIFF
--- a/src/introductions/information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/index.md
+++ b/src/introductions/information-security-and-quality-assurance/quality-assurance-and-testing-with-chai/index.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction to the Quality Assurance with Chai Challenges
-block: Quality Assurance with Chai
+block: Quality Assurance and Testing with Chai
 superBlock: Information Security and Quality Assurance
 ---
 ## Introduction to Quality Assurance with Chai Challenges


### PR DESCRIPTION
Problem: Get 404'd when accessing https://learn.freecodecamp.org/information-security-and-quality-assurance/quality-assurance-and-testing-with-chai
Reason: The `index.md` was missing some words and mismatched with the url, causing 404.

The issue was raised on the main repo: https://github.com/freeCodeCamp/freeCodeCamp/issues/17298