### PR TITLE
Fix scrollbar issues

### DIFF
--- a/src/templates/Challenges/classic/Editor.js
+++ b/src/templates/Challenges/classic/Editor.js
@@ -42,7 +42,12 @@ class Editor extends PureComponent {
         enabled: false
       },
       selectOnLineNumbers: true,
-      wordWrap: 'on'
+      wordWrap: 'on',
+      scrollbar: {
+        horizontal: 'hidden',
+        vertical: 'visible',
+        verticalHasArrows: true
+      }
     };
 
     this._editor = null;

--- a/src/templates/Challenges/classic/classic.css
+++ b/src/templates/Challenges/classic/classic.css
@@ -1,9 +1,16 @@
+.reflex-element {
+  overflow: hidden !important;
+}
+
 .editor {
   height: 100%;
 }
 
 .instructions-panel {
   padding: 0 10px;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .react-monaco-editor-container {
@@ -13,7 +20,7 @@
   align-items: end;
 }
 
-.monaco-menu .action-label { 
+.monaco-menu .action-label {
   color: #a2bd9b;
   letter-spacing: 0.02em;
 }

--- a/src/templates/Challenges/components/Output.js
+++ b/src/templates/Challenges/components/Output.js
@@ -15,11 +15,13 @@ const options = {
     enabled: false
   },
   readOnly: true,
+  wordWrap: 'on',
+  scrollBeyondLastLine: false,
   scrollbar: {
-    vertical: 'hidden',
-    horizontal: 'hidden'
+    horizontal: 'hidden',
+    vertical: 'visible',
+    verticalHasArrows: true
   },
-  wordWrap: 'on'
 };
 
 class Output extends PureComponent {


### PR DESCRIPTION
- Removed horizontal scrollbars: Closes #131
- Removed unnecessary vertical ones, too: Closes Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/17415 (This fix is only for Chrome and Firefox as I'm unsure whether or not we support Safari. I'll try and submit a follow up PR for it if requested.)
- Fixed the editor's scrollbar issue: https://github.com/freeCodeCamp/freeCodeCamp/issues/17293

---
## Screenshots:
### Before the fix
![removed-horizontal](https://user-images.githubusercontent.com/25715018/41090509-9f784f9e-6a6e-11e8-9cae-16282eb94acc.png)
### After the fix
![scrollbar-final](https://user-images.githubusercontent.com/25715018/41090522-a898011e-6a6e-11e8-8755-6111cc57b7ee.png)

---
## What I did:
All of the scrollbars in the first screenshot belong to the `ReflexElement` components. Something was off with the height and width of these components, causing the scrollbars to appear. I spent 2 hours inspecting them but couldn't figure out.

I decided to remove them all by applying `overflow: hidden` to the `.reflex-element` class. The results of this:
- Made the instruction pane unscrollable. I made up for this by applying `overflow-y: auto` to the `.instructions-panel` class. The scrollbar, however, appears when it is needed, unlike that of the parent div.
- Revealed the invisible scrollbar of the editor. I think it was covered/overlapped by the parent's one. I made the scrollbars of both the editor and the output visible, with arrows on the slider to match the browser style. A minor issue with the scrollbars being visible is that it appears even when the editor has only one line of code. This is because [scrollBeyondLastLine](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.idiffeditoroptions.html#scrollbeyondlastline) is `true` by default. I only set it to `false` for the output and left the editor at that.