### PR TITLE
feat: add download solution button

### DIFF
--- a/src/templates/Challenges/classic/Show.js
+++ b/src/templates/Challenges/classic/Show.js
@@ -92,12 +92,12 @@ class ShowClassic extends PureComponent {
       initTests,
       updateChallengeMeta,
       updateSuccessMessage,
-      data: { challengeNode: { files, dashedName, title, fields: { tests } } },
+      data: { challengeNode: { files, title, fields: { tests } } },
       pathContext: { challengeMeta }
     } = this.props;
     createFiles(files);
     initTests(tests);
-    updateChallengeMeta({ ...challengeMeta, dashedName, title });
+    updateChallengeMeta({ ...challengeMeta, title });
     updateSuccessMessage(randomCompliment());
     challengeMounted(challengeMeta.id);
   }
@@ -131,7 +131,6 @@ class ShowClassic extends PureComponent {
           challengeType,
           fields: { blockName },
           title,
-          dashedName,
           description,
           guideUrl
         }
@@ -197,7 +196,7 @@ class ShowClassic extends PureComponent {
           </ReflexElement>
         </ReflexContainer>
 
-        <CompletionModal dashedName={dashedName} />
+        <CompletionModal />
         <HelpModal />
         <ResetModal />
       </Fragment>
@@ -214,7 +213,6 @@ export const query = graphql`
   query ClassicChallenge($slug: String!) {
     challengeNode(fields: { slug: { eq: $slug } }) {
       title
-      dashedName
       guideUrl
       description
       challengeType

--- a/src/templates/Challenges/classic/Show.js
+++ b/src/templates/Challenges/classic/Show.js
@@ -197,7 +197,7 @@ class ShowClassic extends PureComponent {
           </ReflexElement>
         </ReflexContainer>
 
-        <CompletionModal dashedName={dashedName}/>
+        <CompletionModal dashedName={dashedName} />
         <HelpModal />
         <ResetModal />
       </Fragment>

--- a/src/templates/Challenges/classic/Show.js
+++ b/src/templates/Challenges/classic/Show.js
@@ -92,12 +92,12 @@ class ShowClassic extends PureComponent {
       initTests,
       updateChallengeMeta,
       updateSuccessMessage,
-      data: { challengeNode: { files, title, fields: { tests } } },
+      data: { challengeNode: { files, dashedName, title, fields: { tests } } },
       pathContext: { challengeMeta }
     } = this.props;
     createFiles(files);
     initTests(tests);
-    updateChallengeMeta({ ...challengeMeta, title });
+    updateChallengeMeta({ ...challengeMeta, dashedName, title });
     updateSuccessMessage(randomCompliment());
     challengeMounted(challengeMeta.id);
   }
@@ -131,6 +131,7 @@ class ShowClassic extends PureComponent {
           challengeType,
           fields: { blockName },
           title,
+          dashedName,
           description,
           guideUrl
         }
@@ -196,7 +197,7 @@ class ShowClassic extends PureComponent {
           </ReflexElement>
         </ReflexContainer>
 
-        <CompletionModal />
+        <CompletionModal dashedName={dashedName}/>
         <HelpModal />
         <ResetModal />
       </Fragment>
@@ -213,6 +214,7 @@ export const query = graphql`
   query ClassicChallenge($slug: String!) {
     challengeNode(fields: { slug: { eq: $slug } }) {
       title
+      dashedName
       guideUrl
       description
       challengeType

--- a/src/templates/Challenges/components/CompletionModal.js
+++ b/src/templates/Challenges/components/CompletionModal.js
@@ -105,11 +105,9 @@ export class CompletionModal extends PureComponent {
             bsSize='lg'
             bsStyle='primary'
             download={`${dashedName}.json`}
-            href={
-              `data:text/json;charset=utf-8,${
-                encodeURIComponent(JSON.stringify(files))
-              }`
-            }
+            href={`data:text/json;charset=utf-8,${encodeURIComponent(
+              JSON.stringify(files)
+            )}`}
             >
             Download my solution
           </Button>

--- a/src/templates/Challenges/components/CompletionModal.js
+++ b/src/templates/Challenges/components/CompletionModal.js
@@ -14,13 +14,16 @@ import {
   closeModal,
   submitChallenge,
   isCompletionModalOpenSelector,
-  successMessageSelector
+  successMessageSelector,
+  challengeFilesSelector
 } from '../redux';
 
 const mapStateToProps = createSelector(
+  challengeFilesSelector,
   isCompletionModalOpenSelector,
   successMessageSelector,
-  (isOpen, message) => ({
+  (files, isOpen, message) => ({
+    files,
     isOpen,
     message
   })
@@ -43,6 +46,10 @@ const mapDispatchToProps = function(dispatch) {
 
 const propTypes = {
   close: PropTypes.func.isRequired,
+  dashedName: PropTypes.string.isRequired,
+  files: PropTypes.shape({
+    key: PropTypes.string
+  }),
   handleKeypress: PropTypes.func.isRequired,
   isOpen: PropTypes.bool,
   message: PropTypes.string,
@@ -56,7 +63,9 @@ export class CompletionModal extends PureComponent {
       isOpen,
       submitChallenge,
       handleKeypress,
-      message
+      message,
+      files,
+      dashedName
     } = this.props;
     if (isOpen) {
       ga.modalview('/completion-modal');
@@ -90,6 +99,19 @@ export class CompletionModal extends PureComponent {
             onClick={submitChallenge}
             >
             Submit and go to next challenge (Ctrl + Enter)
+          </Button>
+          <Button
+            block={true}
+            bsSize='lg'
+            bsStyle='primary'
+            download={`${dashedName}.json`}
+            href={
+              `data:text/json;charset=utf-8,${
+                encodeURIComponent(JSON.stringify(files))
+              }`
+            }
+            >
+            Download my solution
           </Button>
         </Modal.Footer>
       </Modal>

--- a/src/templates/Challenges/components/CompletionModal.js
+++ b/src/templates/Challenges/components/CompletionModal.js
@@ -15,15 +15,18 @@ import {
   submitChallenge,
   isCompletionModalOpenSelector,
   successMessageSelector,
-  challengeFilesSelector
+  challengeFilesSelector,
+  challengeMetaSelector
 } from '../redux';
 
 const mapStateToProps = createSelector(
   challengeFilesSelector,
+  challengeMetaSelector,
   isCompletionModalOpenSelector,
   successMessageSelector,
-  (files, isOpen, message) => ({
+  (files, challengeMeta, isOpen, message) => ({
     files,
+    challengeMeta,
     isOpen,
     message
   })
@@ -45,8 +48,8 @@ const mapDispatchToProps = function(dispatch) {
 };
 
 const propTypes = {
+  challengeMeta: PropTypes.object.isRequired,
   close: PropTypes.func.isRequired,
-  dashedName: PropTypes.string.isRequired,
   files: PropTypes.shape({
     key: PropTypes.string
   }),
@@ -65,11 +68,12 @@ export class CompletionModal extends PureComponent {
       handleKeypress,
       message,
       files,
-      dashedName
+      challengeMeta: { title = 'untitled' }
     } = this.props;
     if (isOpen) {
       ga.modalview('/completion-modal');
     }
+    const dashedName = title.replace(/ /g, '-').toLowerCase();
     return (
       <Modal
         animation={false}

--- a/src/templates/Challenges/components/CompletionModal.js
+++ b/src/templates/Challenges/components/CompletionModal.js
@@ -108,6 +108,7 @@ export class CompletionModal extends PureComponent {
             block={true}
             bsSize='lg'
             bsStyle='primary'
+            className='btn-primary-invert'
             download={`${dashedName}.json`}
             href={`data:text/json;charset=utf-8,${encodeURIComponent(
               JSON.stringify(files)

--- a/src/templates/Challenges/components/CompletionModal.js
+++ b/src/templates/Challenges/components/CompletionModal.js
@@ -51,7 +51,9 @@ const propTypes = {
   challengeMeta: PropTypes.object.isRequired,
   close: PropTypes.func.isRequired,
   files: PropTypes.shape({
-    key: PropTypes.string
+    indexhtml: PropTypes.shape({
+      contents: PropTypes.string
+    })
   }),
   handleKeypress: PropTypes.func.isRequired,
   isOpen: PropTypes.bool,
@@ -67,7 +69,7 @@ export class CompletionModal extends PureComponent {
       submitChallenge,
       handleKeypress,
       message,
-      files,
+      files: { indexhtml: { contents } = { contents: 'empty' }},
       challengeMeta: { title = 'untitled' }
     } = this.props;
     if (isOpen) {
@@ -111,7 +113,7 @@ export class CompletionModal extends PureComponent {
             className='btn-primary-invert'
             download={`${dashedName}.json`}
             href={`data:text/json;charset=utf-8,${encodeURIComponent(
-              JSON.stringify(files)
+              JSON.stringify(contents)
             )}`}
             >
             Download my solution

--- a/src/templates/Challenges/components/CompletionModal.js
+++ b/src/templates/Challenges/components/CompletionModal.js
@@ -67,12 +67,13 @@ export class CompletionModal extends PureComponent {
       submitChallenge,
       handleKeypress,
       message,
-      files,
+      files = {},
       title
     } = this.props;
     if (isOpen) {
       ga.modalview('/completion-modal');
     }
+    const showDownloadButton = Object.keys(files).length;
     const filesForDownload = Object.keys(files)
       .map(key => files[key])
       .reduce((allFiles, { path, contents }) => ({
@@ -110,18 +111,21 @@ export class CompletionModal extends PureComponent {
             >
             Submit and go to next challenge (Ctrl + Enter)
           </Button>
-          <Button
-            block={true}
-            bsSize='lg'
-            bsStyle='primary'
-            className='btn-primary-invert'
-            download={`${dashedName}.json`}
-            href={`data:text/json;charset=utf-8,${encodeURIComponent(
-              JSON.stringify(filesForDownload)
-            )}`}
-            >
-            Download my solution
-          </Button>
+          {showDownloadButton
+            ? <Button
+                block={true}
+                bsSize='lg'
+                bsStyle='primary'
+                className='btn-primary-invert'
+                download={`${dashedName}.json`}
+                href={`data:text/json;charset=utf-8,${encodeURIComponent(
+                  JSON.stringify(filesForDownload)
+                )}`}
+                >
+                Download my solution
+              </Button>
+            : null
+          }
         </Modal.Footer>
       </Modal>
     );

--- a/src/templates/Challenges/components/completion-modal.css
+++ b/src/templates/Challenges/components/completion-modal.css
@@ -10,3 +10,5 @@
   width: 30vh;
 }
 
+.btn-primary-invert {
+}

--- a/src/templates/Challenges/components/completion-modal.css
+++ b/src/templates/Challenges/components/completion-modal.css
@@ -9,6 +9,3 @@
   height: 30vh;
   width: 30vh;
 }
-
-.btn-primary-invert {
-}


### PR DESCRIPTION
Adds button on challenge completion modal to download users solution.

Passed the challenge `dashedName` to `CompletionModal` as a property, not confident that's the right way to do it.

Button screenshot:
![challengemodaldownloadbutton](https://user-images.githubusercontent.com/16709534/41343821-7e183250-6ef7-11e8-9781-107a60be7a43.png)


solution download:
```
{"indexhtml":{"key":"indexhtml","head":"","tail":"","history":["indexhtml"],"name":"index","ext":"html","path":"index.html","contents":"<style>\n  body {\n    background-color: black;\n    font-family: monospace;\n    color: green;\n  }\n  .pink-text {\n    color: pink;\n  }\n</style>\n<h1 class=\"pink-text\">Hello World!</h1>","error":null,"seed":"<style>\n  body {\n    background-color: black;\n    font-family: monospace;\n    color: green;\n  }\n</style>\n<h1>Hello World!</h1>"}}
```