### PR TITLE
changed logo link to home page

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -11,9 +11,9 @@ function Header() {
   return (
     <header>
       <nav id='top-nav'>
-        <Link className='home-link' to='/'>
+        <a className='home-link' href='https://freecodecamp.org'>
           <NavLogo />
-        </Link>
+        </a>
         <FCCSearch />
         <ul id='top-right-nav'>
           <li>


### PR DESCRIPTION
closes [freeCodeCamp/freeCodeCamp#17533](https://github.com/freeCodeCamp/freeCodeCamp/issues/17533) and #177 

Whenever someone clicked on the logo they were taken to the curriculum page, so I have linked it to home page(https://www.freecodecamp.org). 