### PR TITLE
fix: add cats json for seeding challenges

### DIFF
--- a/static/json/cats.json
+++ b/static/json/cats.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": 0,
+    "imageLink": "https://s3.amazonaws.com/freecodecamp/funny-cat.jpg",
+    "altText": "A white cat wearing a green, helmet shaped melon on its head. ",
+    "codeNames": ["Juggernaut", "Mrs. Wallace", "Buttercup"]
+  },
+  {
+    "id": 1,
+    "imageLink": "https://s3.amazonaws.com/freecodecamp/grumpy-cat.jpg",
+    "altText": "A white cat with blue eyes, looking very grumpy. ",
+    "codeNames": ["Oscar", "Scrooge", "Tyrion"]
+  },
+  {
+    "id": 2,
+    "imageLink": "https://s3.amazonaws.com/freecodecamp/mischievous-cat.jpg",
+    "altText":
+      "A ginger cat with one eye closed and mouth in a grin-like expression. Looking very mischievous. ",
+    "codeNames": ["The Doctor", "Loki", "Joker"]
+  }
+]


### PR DESCRIPTION
Closes #17395

At least 5 challenges in `JSON APIs and Ajax` section depend upon this cats.json file. I have added the `cats.json` file in `/static/json` folder. Now the relative route `/json/cats.json` will correctly serve the `cats.json` file.

Please take look and see if this is the correct way to solve this issue.
.