### PR TITLE
Fix for ctrl key having no impact on submit process

### DIFF
--- a/src/templates/Challenges/project/ProjectForm.js
+++ b/src/templates/Challenges/project/ProjectForm.js
@@ -36,17 +36,61 @@ const options = {
 };
 
 export class ProjectForm extends PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      keysDown: {
+        Control: false,
+        Enter: false
+      }
+    };
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleKeyUp = this.handleKeyUp.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
   componentDidMount() {
     this.props.updateProjectForm({});
+    window.addEventListener('keydown', this.handleKeyDown);
+    window.addEventListener('keyup', this.handleKeyUp);
   }
   componentDidUpdate() {
     this.props.updateProjectForm({});
   }
-  handleSubmit = values => {
-    this.props.openModal('completion');
-    this.props.updateProjectForm(values);
-  };
-
+  componentWillUnmount() {
+    window.removeEventListener('keydown', this.handleKeyDown);
+    window.removeEventListener('keyup', this.handleKeyUp);
+  }
+  handleKeyDown(e) {
+    if (e.key === 'Control') {
+      this.setState(state => ({
+        ...state, keysDown: { ...state.keysDown, Control: true }
+      }));
+    }
+    if (e.key === 'Enter') {
+      this.setState(state => ({
+        ...state, keysDown: { ...state.keysDown, Enter: true }
+      }));
+    }
+  }
+  handleKeyUp(e) {
+    if (e.key === 'Control') {
+      this.setState(state => ({
+        ...state, keysDown: { ...state.keysDown, Control: false }
+      }));
+    }
+    if (e.key === 'Enter') {
+      this.setState(state => ({
+        ...state, keysDown: { ...state.keysDown, Enter: false }
+      }));
+    }
+  }
+  handleSubmit(values) {
+    const { keysDown: { Control, Enter } } = this.state;
+    if (Control && Enter || !Enter) {
+      this.props.openModal('completion');
+      this.props.updateProjectForm(values);
+    }
+  }
   render() {
     const { isSubmitting, isFrontEnd } = this.props;
     const buttonCopy = isSubmitting


### PR DESCRIPTION
A fix for issue 67. Keydown and keyup event listeners added to determine when enter and ctrl are pressed down. 'If' statement added to the handleSubmit function to check these two keys are pressed before submitting. This statement also covers the case that enter is not pressed and so the mouse must have been clicked to submit the form.

Additionally, the handleSubmit function was changed from an arrow function to match the formatting of the other functions.

Tested on my machine (Windows 7, Firefox Quantum 64-bit).