### PR TITLE
Fix: render ReflexSplitter conditionally

### DIFF
--- a/src/templates/Challenges/classic/Show.js
+++ b/src/templates/Challenges/classic/Show.js
@@ -226,7 +226,8 @@ class ShowClassic extends PureComponent {
           <ReflexElement flex={1} {...this.resizeProps}>
             {editors}
           </ReflexElement>
-          <ReflexSplitter propagate={true} {...this.resizeProps} />
+          {showPreview &&
+            <ReflexSplitter propagate={true} {...this.resizeProps} />}
           {showPreview ? (
             <ReflexElement flex={0.7} {...this.resizeProps}>
               <Preview


### PR DESCRIPTION
Close #152 

The change hides and shows the splitter (between the editors and the preview pane) based on the preview pane's presence.

At first, I nested the splitter and the preview pane inside a `<Fragment>` under a single conditional but it didn't work. When the splitter is clicked, it threw an error `this.props.events is undefined`, so I thought the props weren't passed to the splitter somehow. However, splitting them up into two separate conditionals did the job.

I later found that Bouncey did wrap the splitter in a conditional, and got this issue too (https://github.com/leefsmp/Re-Flex/issues/47), but I'm not sure why he decided to put the splitter back out ¯\\\_(ツ)_/¯

The Reflex author also suggested using two conditionals, because
>In the current version only ReflexElement and ReflexSplitter can be direct children of their container

