### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
-    "@freecodecamp/curriculum": "^1.0.4",
+    "@freecodecamp/curriculum": "^1.1.3",
     "adler32": "^0.1.7",
     "auth0-js": "^9.5.1",
     "babel-core": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,9 +92,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@freecodecamp/curriculum@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@freecodecamp/curriculum/-/curriculum-1.0.4.tgz#0f7d1c9a9f733593233a968a7f21d189edd51fa5"
+"@freecodecamp/curriculum@^1.1.3":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@freecodecamp/curriculum/-/curriculum-1.2.0.tgz#83b834b52376f1d609202133fed984e25cfa258d"
 
 "@sinonjs/formatio@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
Closes freecodecamp/curriculum#16 and freecodecamp/freecodecamp#17605 where the sample code was not indented and incomplete links all of which is due to installation of older version of @freecodecamp/curriculum, ie v1.0.4 .
Package.json and yarn.lock have been updated to use the recent version, ie '^1.1.3' .