### PR TITLE
fix: In-page anchor links in iframe

### DIFF
--- a/src/templates/Challenges/utils/frame.js
+++ b/src/templates/Challenges/utils/frame.js
@@ -13,14 +13,17 @@ const mainId = 'fcc-main-frame';
 const testId = 'fcc-test-frame';
 
 // base tag here will force relative links
-// within iframe to point to '/' instead of
+// within iframe to point to '' instead of
 // append to the current challenge url
+// this also allows in-page anchors to work properly
+// rather than load another instance of the learn
+//
 // if an error occurs during initialization
 // the __err prop will be set
 // This is then picked up in client/frame-runner.js during
 // runTestsInTestFrame below
 const createHeader = (id = mainId) => `
-  <base href='/' target='_blank'/>
+  <base href='' />
   <script>
     window.__frameId = '${id}';
     window.onerror = function(msg, url, ln, col, err) {


### PR DESCRIPTION
Removed the base tag from the header of the preview iframe. The href and target attributes were causing links within the iframe to open a new tab and would point to /, which created problems with some challenges where users should link to other in-page elements like a footer.

Closes: https://github.com/freeCodeCamp/freeCodeCamp/issues/17713