### PR TITLE
fix(layout): night mode background color now fits full screen

### DIFF
--- a/src/layouts/layout.css
+++ b/src/layouts/layout.css
@@ -28,4 +28,5 @@ main {
 
 .app-wrapper {
   margin-top: 38px;
+  min-height: calc(100vh - 38px);
 }


### PR DESCRIPTION
adding 100vh property to layout.css in order to make the background color fill the browser window
Closes #203 