### PR TITLE
fix(theme): upcoming lessons readability in night mode

### DIFF
--- a/src/layouts/global.css
+++ b/src/layouts/global.css
@@ -700,6 +700,9 @@ h1, h2, h3, h4, h5, h6 {
 .night .challenge-instructions #MDN-links a {
   color: #f8f8f8;
 }
+.night .intro-toc a {
+  color: #006400;
+}
 .night .fa-github-square {
   color: darkgreen;
 }


### PR DESCRIPTION
This PR fixes #209.

I have added following code in the `global.css` file

```css
.night .intro-toc a {
  color: #006400;
}
```
Here is the screenshot of upcoming lessons after the change:

![image](https://user-images.githubusercontent.com/22813027/42125484-7b5dd960-7c95-11e8-8fb4-9fb414318a4a.png)


Please take a look.