### PR TITLE
fix: add overflow for firefox on instructions panel

### DIFF
--- a/src/templates/Challenges/classic/classic.css
+++ b/src/templates/Challenges/classic/classic.css
@@ -8,7 +8,7 @@
 
 .instructions-panel {
   padding: 0 10px;
-  height: 100%;
+  height: calc(100vh - 38px);
   overflow-x: hidden;
   overflow-y: auto;
 }


### PR DESCRIPTION
closes [freeCodeCamp/freeCodeCamp/#17760](https://github.com/freeCodeCamp/freeCodeCamp/issues/17760),
closes [freeCodeCamp/freeCodeCamp/#17773](https://github.com/freeCodeCamp/freeCodeCamp/issues/17773)

adds back in the vertical scrollbar in firefox only when needed

![say hello](https://user-images.githubusercontent.com/1205639/42127815-2adf0534-7c97-11e8-9a1a-fbddf5a2cfdc.PNG)
![headline](https://user-images.githubusercontent.com/1205639/42127823-3817ff62-7c97-11e8-9c00-8ff8a159d1b5.PNG)
