### PR TITLE
Misspelling: "onNext" is called instead of "next" on an Observable

### DIFF
--- a/src/templates/Challenges/utils/frame.js
+++ b/src/templates/Challenges/utils/frame.js
@@ -83,7 +83,7 @@ const buildProxyConsole = proxyLogger => ctx => {
   const oldLog = ctx.window.console.log.bind(ctx.window.console);
   ctx.window.__console = {};
   ctx.window.__console.log = function proxyConsole(...args) {
-    proxyLogger.onNext(args);
+    proxyLogger.next(args);
     return oldLog(...args);
   };
   return ctx;


### PR DESCRIPTION
Issue freeCodeCamp/freeCodeCamp#17791