### PR TITLE
Added reporting of console.log from editor. Refactored a little.

### DIFF
--- a/src/templates/Challenges/redux/index.js
+++ b/src/templates/Challenges/redux/index.js
@@ -48,6 +48,7 @@ export const types = createTypes(
     'createQuestion',
     'initTests',
     'initConsole',
+    'initLogs',
     'updateConsole',
     'updateChallengeMeta',
     'updateFile',
@@ -55,6 +56,9 @@ export const types = createTypes(
     'updateProjectFormValues',
     'updateSuccessMessage',
     'updateTests',
+    'updateLogs',
+
+    'logsToConsole',
 
     'lockCode',
     'unlockCode',
@@ -95,14 +99,18 @@ export const initTests = createAction(types.initTests);
 export const updateTests = createAction(types.updateTests);
 
 export const initConsole = createAction(types.initConsole);
+export const initLogs = createAction(types.initLogs);
 export const updateChallengeMeta = createAction(types.updateChallengeMeta);
 export const updateFile = createAction(types.updateFile);
 export const updateConsole = createAction(types.updateConsole);
+export const updateLogs = createAction(types.updateLogs);
 export const updateJSEnabled = createAction(types.updateJSEnabled);
 export const updateProjectFormValues = createAction(
   types.updateProjectFormValues
 );
 export const updateSuccessMessage = createAction(types.updateSuccessMessage);
+
+export const logsToConsole = createAction(types.logsToConsole);
 
 export const lockCode = createAction(types.lockCode);
 export const unlockCode = createAction(types.unlockCode);
@@ -180,7 +188,22 @@ export const reducer = handleActions(
       ...state,
       consoleOut: state.consoleOut + '\n' + payload
     }),
-
+    [types.initLogs]: state => ({
+      ...state,
+      logsOut: []
+    }),
+    [types.updateLogs]: (state, { payload }) => ({
+      ...state,
+      logsOut: [...state.logsOut, payload]
+    }),
+    [types.logsToConsole]: (state, { payload }) => ({
+      ...state,
+      consoleOut:
+        state.consoleOut +
+        (state.logsOut.length
+          ? '\n' + payload + '\n' + state.logsOut.join('\n')
+          : '')
+    }),
     [types.updateChallengeMeta]: (state, { payload }) => ({
       ...state,
       challengeMeta: { ...payload }

--- a/src/templates/Challenges/utils/frame.js
+++ b/src/templates/Challenges/utils/frame.js
@@ -137,11 +137,12 @@ export const createMainFramer = (document, getState, proxyLogger) =>
     writeContentToFrame
   );
 
-export const createTestFramer = (document, getState, frameReady) =>
+export const createTestFramer = (document, getState, frameReady, proxyLogger) =>
   flow(
     createFrame(document, getState, testId),
     mountFrame(document),
     addDepsToDocument,
     writeTestDepsToDocument(frameReady),
+    buildProxyConsole(proxyLogger),
     writeContentToFrame
   );


### PR DESCRIPTION
To implement @ktajpuri's suggestion I gave the editor logs their own actions.  This allowed me to suppress the '// console output' message if there are no log and postpone their output until the tests are complete.
Closes #189