### PR TITLE
Fix: Removed old jquery CDN and added a more accessible CDN

### DIFF
--- a/src/templates/Challenges/utils/build.js
+++ b/src/templates/Challenges/utils/build.js
@@ -19,7 +19,7 @@ import { cssToHtml, jsToHtml, concatHtml } from '../rechallenge/builders.js';
 import { createFileStream, pipe } from './polyvinyl';
 
 const jQuery = {
-  src: 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js'
+  src: 'https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js'
 };
 const frameRunner = {
   src: '/js/frame-runner.js',


### PR DESCRIPTION
I added the new CDN that @raisedadead suggested in [#155](https://github.com/freeCodeCamp/learn/issues/155)

Closes [#155](https://github.com/freeCodeCamp/learn/issues/155)