### PR TITLE
Fix: 404 page quote in Night Mode

### DIFF
--- a/src/layouts/global.css
+++ b/src/layouts/global.css
@@ -782,3 +782,11 @@ code[class*="language-"],pre[class*="language-"] {
 .night blockquote, .night .challenge-instructions blockquote {
     color: #00bfb0;
 }
+
+.night .notfound-page-wrapper .quote-wrapper {
+  background-color: #222;
+}
+
+.night .notfound-page-wrapper .btn-curriculum {
+  color: #292f33;
+}


### PR DESCRIPTION
Hi, I added a dark background of the quote container so that it will be visible in Night Mode. Also, I added the color of the curriculum button to stay as is in Night Mode.

Closes #237 

![freecodecamp-404-page-night-mode](https://user-images.githubusercontent.com/25174423/42741105-f04df0ae-88e1-11e8-926d-b538876a8c48.png)