### PR TITLE
fix/change mathjax delimiters

### DIFF
--- a/src/head/index.js
+++ b/src/head/index.js
@@ -1,10 +1,10 @@
 import favicons from './favicons';
 import meta from './meta';
 import styleSheets from './styleSheets';
-// import mathjax from './mathjax';
+import mathjax from './mathjax';
 
 const metaAndStyleSheets = meta
-  .concat(favicons, styleSheets)
+  .concat(favicons, styleSheets, mathjax)
   .map((element, i) => ({ ...element, key: `meta-stylesheet-${i}` }));
 
 export default metaAndStyleSheets;

--- a/src/templates/Challenges/components/Side-Panel.js
+++ b/src/templates/Challenges/components/Side-Panel.js
@@ -26,7 +26,7 @@ const mapDispatchToProps = dispatch =>
     dispatch
   );
 
-// const MathJax = global.MathJax;
+const MathJax = global.MathJax;
 
 const propTypes = {
   description: PropTypes.arrayOf(PropTypes.string),
@@ -43,17 +43,20 @@ export class SidePanel extends PureComponent {
     // MathJax.Hub.Config({
     //   tex2jax: { inlineMath: [['$', '$'], ['\\(', '\\)']] }
     // });
+    MathJax.Hub.Config({
+      tex2jax: { inlineMath: [['$$', '$$']] }
+    });
   }
 
   componentDidMount() {
-    // MathJax.Hub.Queue(['Typeset', MathJax.Hub,
-    // document.querySelector('.challenge-instructions')]);
+    MathJax.Hub.Queue(['Typeset', MathJax.Hub,
+    document.querySelector('.challenge-instructions')]);
     this.props.initConsole('');
   }
 
   componentDidUpdate(prevProps) {
-    // MathJax.Hub.Queue(['Typeset', MathJax.Hub,
-    // document.querySelector('.challenge-instructions')]);
+    MathJax.Hub.Queue(['Typeset', MathJax.Hub,
+    document.querySelector('.challenge-instructions')]);
     const { title, initConsole } = this.props;
     if (title !== prevProps.title) {
       initConsole('');

--- a/src/templates/Challenges/components/Side-Panel.js
+++ b/src/templates/Challenges/components/Side-Panel.js
@@ -40,11 +40,8 @@ export class SidePanel extends PureComponent {
   constructor(props) {
     super(props);
     this.bindTopDiv = this.bindTopDiv.bind(this);
-    // MathJax.Hub.Config({
-    //   tex2jax: { inlineMath: [['$', '$'], ['\\(', '\\)']] }
-    // });
     MathJax.Hub.Config({
-      tex2jax: { inlineMath: [['$$', '$$']] }
+      tex2jax: { inlineMath: [['$inlineMath$', '$inlineMath$']] }
     });
   }
 


### PR DESCRIPTION
Reimplemented MathJax with custom $inlineMath$ delimeters to prevent it from rendering SASS and other challenge descriptions as math functions.