### PR TITLE
fix: on error preview is disabled 

### DIFF
--- a/src/templates/Challenges/rechallenge/transformers.js
+++ b/src/templates/Challenges/rechallenge/transformers.js
@@ -87,7 +87,7 @@ function tryTransform(wrap = identity) {
       // At the minute, it will not bubble up
       // We collapse the pipeline so the app doesn't fall over trying
       // parse bad code (syntax/type errors etc...)
-      throw new Error();
+      throw result;
     }
     return result;
   };

--- a/src/templates/Challenges/redux/code-lock-epic.js
+++ b/src/templates/Challenges/redux/code-lock-epic.js
@@ -3,7 +3,7 @@ import { ofType } from 'redux-observable';
 import { types, unlockCode } from './';
 
 function codeLockEpic(action$) {
-  return action$.pipe(ofType(types.executeChallenge), map(unlockCode));
+  return action$.pipe(ofType(types.updateFile), map(unlockCode));
 }
 
 export default codeLockEpic;

--- a/src/templates/Challenges/redux/execute-challenge-epic.js
+++ b/src/templates/Challenges/redux/execute-challenge-epic.js
@@ -50,7 +50,6 @@ function updateMainEpic(actions, { getState }, { document }) {
       const buildAndFrameMain = actions.pipe(
         ofType(
           types.updateFile,
-          types.executeChallenge,
           types.challengeMounted
         ),
         debounceTime(executeDebounceTimeout),
@@ -58,6 +57,7 @@ function updateMainEpic(actions, { getState }, { document }) {
           buildFromFiles(getState(), true).pipe(
             map(frameMain),
             ignoreElements(),
+            startWith(initConsole('')),
             catchError(err => of(disableJSOnError(err)))
           )
         )

--- a/src/templates/Challenges/redux/index.js
+++ b/src/templates/Challenges/redux/index.js
@@ -106,13 +106,7 @@ export const updateSuccessMessage = createAction(types.updateSuccessMessage);
 
 export const lockCode = createAction(types.lockCode);
 export const unlockCode = createAction(types.unlockCode);
-export const disableJSOnError = createAction(
-  types.disableJSOnError,
-  ({ payload }) => {
-    console.error(JSON.stringify(payload));
-    return null;
-  }
-);
+export const disableJSOnError = createAction(types.disableJSOnError);
 export const storedCodeFound = createAction(types.storedCodeFound);
 export const noStoredCodeFound = createAction(types.noStoredCodeFound);
 
@@ -222,8 +216,9 @@ export const reducer = handleActions(
       isJSEnabled: true,
       isCodeLocked: false
     }),
-    [types.disableJSOnError]: state => ({
+    [types.disableJSOnError]: (state, { payload }) => ({
       ...state,
+      consoleOut: state.consoleOut + '\n' + payload,
       isJSEnabled: false
     }),
 


### PR DESCRIPTION
I expect to see a preview while a challenge is edited, and it is so in HTML/CSS/SASS challenges. But in JS/React challenges most of the time a preview not working.

Now preview is disabled on syntax errors in the editor and will be enabled only after press "Run tests".

The PR is correcting this behavior.