### PR TITLE
Added a few styles to increase heirarchy of curriculum list

### DIFF
--- a/src/components/Map/map.css
+++ b/src/components/Map/map.css
@@ -18,6 +18,9 @@
   display: flex;
   align-items: center;
   cursor: pointer;
+  padding-top: 10px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #e2e2e2;
 }
 
 .map-title>svg {


### PR DESCRIPTION
I added 3 lines of styles which, in my opinion, make the curriculum list a lot cleaner and separated per track. I've attached before and after screenshots so that you see what I mean (they are kinda tall):
--- After
<img width="890" alt="after-tab-open" src="https://user-images.githubusercontent.com/13972034/43035873-a4437d82-8cc4-11e8-981b-2232ecc0ab47.png">
--- After
<img width="782" alt="after-tabs-closed" src="https://user-images.githubusercontent.com/13972034/43035874-a452a0b4-8cc4-11e8-91de-0891fa98ab2c.png">
--- Before
<img width="842" alt="before-tab-open" src="https://user-images.githubusercontent.com/13972034/43035875-a45cdd2c-8cc4-11e8-9eb8-818003d504e0.png">
--- Before
<img width="801" alt="before-tabs-closed" src="https://user-images.githubusercontent.com/13972034/43035876-a466e97a-8cc4-11e8-8672-48e1a4d2a64b.png">




