### PR TITLE
fix: reenable mathjax for rosetta code

### DIFF
--- a/src/head/index.js
+++ b/src/head/index.js
@@ -1,10 +1,10 @@
 import favicons from './favicons';
 import meta from './meta';
 import styleSheets from './styleSheets';
-// import mathjax from './mathjax';
+import mathjax from './mathjax';
 
 const metaAndStyleSheets = meta
-  .concat(favicons, styleSheets)
+  .concat(favicons, styleSheets, mathjax)
   .map((element, i) => ({ ...element, key: `meta-stylesheet-${i}` }));
 
 export default metaAndStyleSheets;

--- a/src/html.js
+++ b/src/html.js
@@ -50,6 +50,7 @@ function HTML(props) {
       <body {...bodyAttributes}>
         {preBodyComponents}
         <div
+          className='tex2jax_ignore'
           dangerouslySetInnerHTML={{ __html: body }}
           id='___gatsby'
           key={'body'}

--- a/src/templates/Challenges/classic/Show.js
+++ b/src/templates/Challenges/classic/Show.js
@@ -19,6 +19,7 @@ import { randomCompliment } from '../utils/get-words';
 import { createGuideUrl } from '../utils';
 import { challengeTypes } from '../../../../utils/challengeTypes';
 import { ChallengeNode } from '../../../redux/propTypes';
+import { dasherize } from '../../../../utils';
 import {
   createFiles,
   challengeFilesSelector,
@@ -220,6 +221,7 @@ class ShowClassic extends PureComponent {
               className='full-height'
               description={description}
               guideUrl={createGuideUrl(slug)}
+              section={dasherize(blockName)}
               title={blockNameTitle}
             />
           </ReflexElement>

--- a/src/templates/Challenges/components/Challenge-Description.js
+++ b/src/templates/Challenges/components/Challenge-Description.js
@@ -6,7 +6,8 @@ import { descriptionRegex } from '../../../../utils';
 import './challenge-description.css';
 
 const propTypes = {
-  description: PropTypes.arrayOf(PropTypes.string)
+  description: PropTypes.arrayOf(PropTypes.string),
+  section: PropTypes.string
 };
 
 function renderDescription(description) {
@@ -32,11 +33,11 @@ function renderDescription(description) {
   });
 }
 
-function ChallengeDescription({ description }) {
+function ChallengeDescription({ description, section }) {
   // TODO: Remove bootstrap
   return (
     <Row>
-      <Col className='challenge-instructions' xs={12}>
+      <Col className={`challenge-instructions ${section}`} xs={12}>
         {renderDescription(description)}
       </Col>
     </Row>

--- a/src/templates/Challenges/components/Side-Panel.js
+++ b/src/templates/Challenges/components/Side-Panel.js
@@ -26,7 +26,7 @@ const mapDispatchToProps = dispatch =>
     dispatch
   );
 
-// const MathJax = global.MathJax;
+const MathJax = global.MathJax;
 
 const propTypes = {
   description: PropTypes.arrayOf(PropTypes.string),
@@ -43,17 +43,20 @@ export class SidePanel extends PureComponent {
     // MathJax.Hub.Config({
     //   tex2jax: { inlineMath: [['$', '$'], ['\\(', '\\)']] }
     // });
+    MathJax.Hub.Config({
+      tex2jax: { inlineMath: [['$$', '$$']] }
+    });
   }
 
   componentDidMount() {
-    // MathJax.Hub.Queue(['Typeset', MathJax.Hub,
-    // document.querySelector('.challenge-instructions')]);
+    MathJax.Hub.Queue(['Typeset', MathJax.Hub,
+    document.querySelector('.challenge-instructions')]);
     this.props.initConsole('');
   }
 
   componentDidUpdate(prevProps) {
-    // MathJax.Hub.Queue(['Typeset', MathJax.Hub,
-    // document.querySelector('.challenge-instructions')]);
+    MathJax.Hub.Queue(['Typeset', MathJax.Hub,
+    document.querySelector('.challenge-instructions')]);
     const { title, initConsole } = this.props;
     if (title !== prevProps.title) {
       initConsole('');

--- a/src/templates/Challenges/components/Side-Panel.js
+++ b/src/templates/Challenges/components/Side-Panel.js
@@ -32,6 +32,7 @@ const propTypes = {
   description: PropTypes.arrayOf(PropTypes.string),
   guideUrl: PropTypes.string,
   initConsole: PropTypes.func.isRequired,
+  section: PropTypes.string,
   tests: PropTypes.arrayOf(PropTypes.object),
   title: PropTypes.string
 };
@@ -41,19 +42,23 @@ export class SidePanel extends PureComponent {
     super(props);
     this.bindTopDiv = this.bindTopDiv.bind(this);
     MathJax.Hub.Config({
-      tex2jax: { inlineMath: [['$inlineMath$', '$inlineMath$']] }
+      tex2jax: { 
+        inlineMath: [['$', '$'], ['\\(', '\\)']],
+        processEscapes: true,
+        processClass: 'rosetta-code'
+      }
     });
   }
 
   componentDidMount() {
     MathJax.Hub.Queue(['Typeset', MathJax.Hub,
-    document.querySelector('.challenge-instructions')]);
+    document.querySelector('.rosetta-code')]);
     this.props.initConsole('');
   }
 
   componentDidUpdate(prevProps) {
     MathJax.Hub.Queue(['Typeset', MathJax.Hub,
-    document.querySelector('.challenge-instructions')]);
+    document.querySelector('.rosetta-code')]);
     const { title, initConsole } = this.props;
     if (title !== prevProps.title) {
       initConsole('');
@@ -69,14 +74,14 @@ export class SidePanel extends PureComponent {
   }
 
   render() {
-    const { title, description, guideUrl, tests } = this.props;
+    const { title, description, guideUrl, tests, section } = this.props;
     return (
       <div className='instructions-panel' role='complementary'>
         <div ref={this.bindTopDiv} />
         <Spacer />
         <div>
           <ChallengeTitle>{title}</ChallengeTitle>
-          <ChallengeDescription description={description} />
+          <ChallengeDescription section={section} description={description} />
         </div>
         <ToolPanel guideUrl={guideUrl} />
         <TestSuite tests={tests} />

--- a/src/templates/Challenges/components/Side-Panel.js
+++ b/src/templates/Challenges/components/Side-Panel.js
@@ -40,11 +40,8 @@ export class SidePanel extends PureComponent {
   constructor(props) {
     super(props);
     this.bindTopDiv = this.bindTopDiv.bind(this);
-    // MathJax.Hub.Config({
-    //   tex2jax: { inlineMath: [['$', '$'], ['\\(', '\\)']] }
-    // });
     MathJax.Hub.Config({
-      tex2jax: { inlineMath: [['$$', '$$']] }
+      tex2jax: { inlineMath: [['$inlineMath$', '$inlineMath$']] }
     });
   }
 


### PR DESCRIPTION
Did some retooling and was able to disable MathJax for the entire page from a top-level div by adding the class name tex2jax_ignore. Brought the dasherize function into Show.js and used it to pass a new prop section down through Side-Panel.js into Challenge-Description.js to add a section class name to each of the challenge-instructions divs. Then was able to use the `$...$` delimiters that caused problems before, but only for the Rosetta Code challenges.