### PR TITLE
Make fcc gatsby plugin watch .json files in the curriculum package

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -19,7 +19,8 @@ module.exports = {
       resolve: 'fcc-source-challenges',
       options: {
         name: 'challenges',
-        path: path.resolve(__dirname, './seed/challenges'),
+        path: require.resolve('@freecodecamp/curriculum')
+          .replace('/index.js', '').concat('/challenges/'),
         source: buildChallenges$
       }
     },

--- a/plugins/fcc-source-challenges/create-Challenge-nodes.js
+++ b/plugins/fcc-source-challenges/create-Challenge-nodes.js
@@ -17,6 +17,8 @@ function createChallengeNodes(challenge, reporter) {
     type: 'ChallengeNode'
   };
 
+// NOTE: Due to the assignment sequence, challenge.id does not get
+// ' >>>> ChallengeNode' appended.  Swap them?
   /* eslint-disable prefer-object-spread/prefer-object-spread */
   return JSON.parse(
     JSON.stringify(

--- a/plugins/fcc-source-challenges/gatsby-node.js
+++ b/plugins/fcc-source-challenges/gatsby-node.js
@@ -9,22 +9,12 @@ exports.sourceNodes = ({ boundActionCreators, reporter }, pluginOptions) => {
 that delivers challenge files to the plugin
       `);
   }
-  // TODO: Add live seed updates
   const { createNode } = boundActionCreators;
 
-  let ready = false;
+  // Watch the json files in @freecodecamp/curriculum/dist/challenges
+  // TODO consider ignoring in production.
 
-  const watcher = chokidar.watch(pluginOptions.path, {
-    ignored: [
-      '**/*.un~',
-      '**/.gitignore',
-      '**/.npmignore',
-      '**/.babelrc',
-      '**/yarn.lock',
-      '**/node_modules',
-      '../**/dist/**'
-    ]
-  });
+  const watcher = chokidar.watch(pluginOptions.path + '**/*.json');
   const { source } = pluginOptions;
   const createAndProcessNodes = () =>
     source()
@@ -34,38 +24,13 @@ that delivers challenge files to the plugin
       .subscribe();
 
   createAndProcessNodes();
-  // For every path that is reported before the 'ready' event, we throw them
-  // into a queue and then flush the queue when 'ready' event arrives.
-  // After 'ready', we handle the 'add' event without putting it into a queue.
-  let pathQueue = [];
-  const flushPathQueue = () => {
-    let queue = pathQueue.slice();
-    pathQueue = [];
-    return Promise.all(queue.map(createAndProcessNodes));
-  };
-
-  // watcher.on('change', path => {
-  //   reporter.info(`changed file at ${path}`);
-  //   createAndProcessNodes().catch(err => reporter.error(err));
-  // });
-
-  // watcher.on('unlink', path => {
-  //   reporter.info(`file deleted at ${path}`);
-  //   const node = getNode(createId(path));
-  //   // It's possible the file node was never created as sometimes tools will
-  //   // write and then immediately delete temporary files to the file system.
-  //   if (node) {
-  //     deleteNode(node.id, node);
-  //   }
-  // });
-
-  return new Promise((resolve, reject) => {
-    watcher.on('ready', () => {
-      if (ready) {
-        return;
-      }
-      ready = true;
-      flushPathQueue().then(resolve, reject);
-    });
+  // If any files have changed, rebuild all challenges
+  watcher.on('change', path => {
+     reporter.info(`changed file at ${path}`);
+     createAndProcessNodes();
   });
+
+  // There does not seem to be a need to deal the 'ready' event, as any
+  // changes before 'ready' are completely ignored by chokidar and any changes
+  // after are dealt with properly.
 };


### PR DESCRIPTION
The main change is to add a watch that rebuilds the challenges after it detects a change in `curriculum`.  There was also some code that was not being used, that's been cut.

Fixes #242