### PR TITLE
fix logo link url

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -11,7 +11,7 @@ function Header() {
   return (
     <header>
       <nav id='top-nav'>
-        <a className='home-link' href='https://freecodecamp.org'>
+        <a className='home-link' href='https://www.freecodecamp.org'>
           <NavLogo />
         </a>
         <FCCSearch />


### PR DESCRIPTION
I found the logo URL  is wrong.
When I clicked the Logo, it goes 'https://www.freecodecamp.org%26request_uri/'.
So I fixed it!