### PR TITLE
Fix/nightmode links

### DIFF
--- a/src/components/Map/map.css
+++ b/src/components/Map/map.css
@@ -34,6 +34,10 @@ li.open > .map-title svg {
   margin-bottom: 0.25rem;
 }
 
+.map-challenge-title a  {
+    color: #f8f8f8;
+}
+
 .map-challenge-title-completed {
   opacity: 0.5;
 }

--- a/src/layouts/global.css
+++ b/src/layouts/global.css
@@ -698,10 +698,12 @@ code[class*="language-"],pre[class*="language-"] {
   color: #004a00;
 }
 .night a,
-.night .input-group-addon,
 .night .challenge-instructions a,
 .night .challenge-instructions #MDN-links a {
-  color: #f8f8f8;
+  color: #02a902;
+}
+.night .input-group-addon {
+    color: #f8f8f8;
 }
 .night .intro-toc a {
   color: #006400;
@@ -765,10 +767,10 @@ code[class*="language-"],pre[class*="language-"] {
   color: #fff;
 }
 
-.night .test-result:nth-child(odd) { 
-  color: #fff; 
-  background: #2A2A2A; 
-} 
+.night .test-result:nth-child(odd) {
+  color: #fff;
+  background: #2A2A2A;
+}
 
 .night .challenge-preview {
   background: #fff;


### PR DESCRIPTION
fix for https://github.com/freeCodeCamp/freeCodeCamp/issues/17946

Made most a tags green. Kept the links in the the curriculum page the same shade of white to avoid confusion and adding too much color

screenshots:
before:
<img width="1272" alt="screen shot 2018-07-29 at 4 04 54 pm" src="https://user-images.githubusercontent.com/24216993/43370290-c58e46f2-934a-11e8-87d0-626ba92e2860.png">
<img width="1267" alt="screen shot 2018-07-29 at 4 04 41 pm" src="https://user-images.githubusercontent.com/24216993/43370291-c5999c1e-934a-11e8-9984-123dfafb96b6.png">


after:
<img width="1264" alt="screen shot 2018-07-29 at 3 48 43 pm" src="https://user-images.githubusercontent.com/24216993/43370205-fe88b07a-9348-11e8-907f-84b91b611350.png">
<img width="1272" alt="screen shot 2018-07-29 at 3 48 11 pm" src="https://user-images.githubusercontent.com/24216993/43370207-ffeb2966-9348-11e8-84cf-eba3a7c9be8e.png">
