### PR TITLE
fix(map): Corrected the color of challenge titles in normal mode

### DIFF
--- a/src/components/Map/map.css
+++ b/src/components/Map/map.css
@@ -37,7 +37,7 @@ li.open > .map-title svg {
   margin-bottom: 0.25rem;
 }
 
-.map-challenge-title a  {
+.night .map-challenge-title a  {
     color: #f8f8f8;
 }
 


### PR DESCRIPTION
In PR #255, the changes to challenge titles was not restricted to night mode only so even in normal mode the challenge titles have a white color which is hard to see.

CLOSES: [freeCodeCamp/#18110](https://github.com/freeCodeCamp/freeCodeCamp/issues/18110), #286 

Sry for mistakenly approving(I'm an idiot 😢) the PR which caused this issue. 