### PR TITLE
fix(console): output user logs after running tests

### DIFF
--- a/src/templates/Challenges/rechallenge/transformers.js
+++ b/src/templates/Challenges/rechallenge/transformers.js
@@ -31,25 +31,12 @@ const babelTransformCode = code => Babel.transform(code, babelOptions).code;
 
 // const sourceReg =
 //  /(<!-- fcc-start-source -->)([\s\S]*?)(?=<!-- fcc-end-source -->)/g;
-const console$logReg = /(?:\b)console(\.log\S+)/g;
 const NBSPReg = new RegExp(String.fromCharCode(160), 'g');
 
 const isJS = matchesProperty('ext', 'js');
 const testHTML = matchesProperty('ext', 'html');
 const testHTMLJS = overSome(isJS, testHTML);
 export const testJS$JSX = overSome(isJS, matchesProperty('ext', 'jsx'));
-
-// if shouldProxyConsole then we change instances of console log
-// to `window.__console.log`
-// this let's us tap into logging into the console.
-// currently we only do this to the main window and not the test window
-export const proxyLoggerTransformer = partial(
-  vinyl.transformHeadTailAndContents,
-  source =>
-    source.replace(console$logReg, (match, methodCall) => {
-      return 'window.__console' + methodCall;
-    })
-);
 
 export const replaceNBSP = cond([
   [

--- a/src/templates/Challenges/utils/build.js
+++ b/src/templates/Challenges/utils/build.js
@@ -1,6 +1,5 @@
 import { combineLatest } from 'rxjs/observable/combineLatest';
 import { map } from 'rxjs/operators/map';
-import identity from 'lodash/identity';
 
 import { fetchScript } from './fetch-and-cache.js';
 import throwers from '../rechallenge/throwers';
@@ -12,7 +11,6 @@ import {
 } from '../redux';
 import {
   applyTransformers,
-  proxyLoggerTransformer,
   testJS$JSX
 } from '../rechallenge/transformers';
 import { cssToHtml, jsToHtml, concatHtml } from '../rechallenge/builders.js';
@@ -40,7 +38,7 @@ function filterJSIfDisabled(state) {
   return file => !(testJS$JSX(file) && !isJSEnabled);
 }
 
-export function buildFromFiles(state, shouldProxyConsole) {
+export function buildFromFiles(state) {
   const files = challengeFilesSelector(state);
   const { required, template } = challengeMetaSelector(state);
   const finalRequires = [...globalRequires, ...required];
@@ -51,7 +49,6 @@ export function buildFromFiles(state, shouldProxyConsole) {
   return createFileStream(requiredFiles)
     ::pipe(throwers)
     ::pipe(applyTransformers)
-    ::pipe(shouldProxyConsole ? proxyLoggerTransformer : identity)
     ::pipe(jsToHtml)
     ::pipe(cssToHtml)
     ::concatHtml(finalRequires, template);

--- a/src/templates/Challenges/utils/frame.js
+++ b/src/templates/Challenges/utils/frame.js
@@ -84,8 +84,7 @@ const addDepsToDocument = ctx => {
 
 const buildProxyConsole = proxyLogger => ctx => {
   const oldLog = ctx.window.console.log.bind(ctx.window.console);
-  ctx.window.__console = {};
-  ctx.window.__console.log = function proxyConsole(...args) {
+  ctx.window.console.log = function proxyConsole(...args) {
     proxyLogger.next(args);
     return oldLog(...args);
   };
@@ -140,11 +139,12 @@ export const createMainFramer = (document, getState, proxyLogger) =>
     writeContentToFrame
   );
 
-export const createTestFramer = (document, getState, frameReady) =>
+export const createTestFramer = (document, getState, frameReady, proxyLogger) =>
   flow(
     createFrame(document, getState, testId),
     mountFrame(document),
     addDepsToDocument,
     writeTestDepsToDocument(frameReady),
+    buildProxyConsole(proxyLogger),
     writeContentToFrame
   );


### PR DESCRIPTION
This is a possible fix for #189.  The problem highlighted by #291 was that if both the tests and the test runner interact with console.log, they can clash.  Because of how `proxyLoggerTransformer` rewrote the challenge source, challenges like [Write Reusable JavaScript with Functions](https://github.com/freeCodeCamp/curriculum/blob/ddcc661f425d851f85d13bd47155e2f20e018ed7/challenges/02-javascript-algorithms-and-data-structures/basic-javascript.json#L3060-L3076) would never get their proxy console.logs called.

To avoid this, the test-runner in this PR modifies the frame's console.log directly.  This means that the frame-runner's log is called first, which sends the message to the user log area, then calls test's proxy (if there is one) and that ends calling the native function.

There is a side effect of this.  Now any console.log calls in the tests themselves will appear in the user log area.  Arguably these logs should not be there anyway, but the fact remains that there are some.  If this PR seems good, I'd be happy to trawl through curriculum and remove any offending log calls.