### PR TITLE
remove challenge name as title when user click the Ask for Help

### DIFF
--- a/src/templates/Challenges/redux/create-question-epic.js
+++ b/src/templates/Challenges/redux/create-question-epic.js
@@ -50,7 +50,9 @@ function createQuestionEpic(action$, { getState }, { window }) {
         'User Agent is: <code>',
         userAgent,
         '</code>.\n\n',
-        '**Link to the challenge:**\n',
+        '**Challenge:**\n',
+        challengeTitle,
+        '\n**Link to the challenge:**\n',
         href
       ].join('');
       const categories = ['HTML-CSS', 'JavaScript'];
@@ -59,7 +61,6 @@ function createQuestionEpic(action$, { getState }, { window }) {
           '?category=' +
           window.encodeURIComponent(categories[challengeType] || 'Help') +
           '&title=' +
-          window.encodeURIComponent(challengeTitle) +
           '&body=' +
           window.encodeURIComponent(textMessage),
         '_blank'


### PR DESCRIPTION
As requested by a forum moderator remove challenge name as title when user click the Ask for Help.

This close [freeCodeCamp#18088](https://github.com/freeCodeCamp/freeCodeCamp/issues/18088#issue-357253301)