### PR TITLE
Updated intro to Readux, added a missing word

### DIFF
--- a/src/introductions/front-end-libraries/redux/index.md
+++ b/src/introductions/front-end-libraries/redux/index.md
@@ -5,6 +5,6 @@ superBlock: Front End Libraries
 ---
 ## Introduction to the Redux Challenges
 
-[Redux](https://redux.js.org/) is a predictable state container for JavaScript apps. It helps you write applications that behave consistently, run in different environments (client, server, and native), and are easy to test. While you can use Redux with any view library, it's introduced here before being combined with React.
+[Redux](https://redux.js.org/) is a predictable state container for JavaScript apps. It helps you to write applications that behave consistently, run in different environments (client, server, and native), and are easy to test. While you can use Redux with any view library, it's introduced here before being combined with React.
 
 Improve this intro on [GitHub](https://github.com/freeCodeCamp/learn/tree/master/src/introductions/front-end-libraries/redux).


### PR DESCRIPTION
I added a small word to this intro. This word is 'to'. I think it makes sense but not important to place it.
I have the passion to contribute to open source free education platform.
It's totally optional to accept this tiny change.